### PR TITLE
 Change commit hex to tx id hex 

### DIFF
--- a/claim.js
+++ b/claim.js
@@ -287,8 +287,8 @@ function setTopFee() {
   // Format the BTC address and commit
   let fullAddress = segwitAddrEncodeFull(topFeeClaim[0].Commitment);
   let formattedAddress = fullAddress.substring(0, 6) + "..." + fullAddress.substring(fullAddress.length - 4);
-  let fullCommit = topFeeClaim[0].Commitment;
-  let formattedCommit = fullCommit.substring(0, 6) + "..." + fullCommit.substring(fullCommit.length - 4);
+  let fullTxId = topFeeClaim[0].TxId;
+  let formattedTxId = fullTxId.substring(0, 6) + "..." + fullTxId.substring(fullTxId.length - 4);
 
   // Set the top fee value
   document.getElementById("topFeeMBTC").innerText = 
@@ -298,7 +298,7 @@ function setTopFee() {
   let topFeeAddrDiv = document.getElementById("topFeeAddr");
   topFeeAddrDiv.innerHTML = ""; // Clear previous content
   topFeeAddrDiv.appendChild(createClickableElement(formattedAddress, fullAddress));
-  topFeeAddrDiv.appendChild(createClickableElement(formattedCommit, fullCommit));
+  topFeeAddrDiv.appendChild(createClickableElement(formattedTxId, fullTxId));
 
   // Update the transaction list with clickable formatted BTC addresses
   document.getElementById("transactionList").innerHTML = "";


### PR DESCRIPTION
It's useful to lookup claim by tx id hex,
Commit hex should be converted to address only, not shown to the user.
